### PR TITLE
Halpy returns an undefined url when creating room via DM

### DIFF
--- a/scripts/zoom.coffee
+++ b/scripts/zoom.coffee
@@ -60,7 +60,7 @@ module.exports = (robot) ->
               else
                 descriptor = if is_recorded then "recorded" else ""
                 join_url = json_body.join_url
-                join_url = if is_recorded then landing_disclaimer_url + join_url
+                join_url = if is_recorded then landing_disclaimer_url + join_url else join_url
                 msg.send "#{username} started a #{descriptor} zoom session: #{join_url}"
             else
               msg.send "zoom? more like doom! there was a problem sending the request :("


### PR DESCRIPTION
From private slack convo

> Hmm. Just tried opening a DM with @halpy and then running the command without his handle like  this:kyalashea [12:08 PM]
> zoom me now My Fancy MeetinghalpyAPP [12:08 PM]
> kyalashea started a  zoom session: undefined
> 3:10
> Is that right and if so should Zoom launch?

h/t @suchthis 