### PR TITLE
Add maintenance status notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Halpy
 
+**NOTE: Halpy is not actively maintained. It needs major updates to Hubot and other dependencies, and EDGI members have not had time to keep up with it. If you’re interested in helping out by maintaining Halpy, let us know on the #tools_talk channel of the EDGI Slack.**
+
 Halpy is a chat bot used by the Environmental Data & Governance
 Initiative (EDGI) to assist us in our Slack chat.
 


### PR DESCRIPTION
On the heels of #46, this PR adds a short notice to the README that Halpy is not currently maintained and info about where someone can go to get involved if they want to work on it.

I’ve made Slack (instead of Github issues) the place to go so that it still makes sense if we archive this repo.